### PR TITLE
Handle pep8 -> pycodestyle rename.

### DIFF
--- a/ebb_lint/flake8.py
+++ b/ebb_lint/flake8.py
@@ -8,7 +8,7 @@ import sys
 from lib2to3.pgen2 import driver, token, tokenize
 from lib2to3 import patcomp, pygram, pytree
 
-import pep8
+import pycodestyle
 import six
 import venusian
 from intervaltree import Interval, IntervalTree
@@ -18,9 +18,9 @@ from ebb_lint.errors import Errors
 from ebb_lint import checkers
 
 
-_pep8_noqa = pep8.noqa
+_pycodestyle_noqa = pycodestyle.noqa
 # This is a blight. Disable it unconditionally.
-pep8.noqa = lambda ign: False
+pycodestyle.noqa = lambda ign: False
 
 
 def tokenize_source_string(s, base_byte=0):
@@ -237,10 +237,10 @@ class EbbLint(object):
                 # On python 2, reading from stdin gives you bytes, which must
                 # be decoded.
                 self._source = decode_string_using_source_encoding(
-                    pep8.stdin_get_value())
+                    pycodestyle.stdin_get_value())
             else:  # ✘py27
                 # On python 3, reading from stdin gives you text.
-                self._source = pep8.stdin_get_value()
+                self._source = pycodestyle.stdin_get_value()
         return self._source
 
     @property
@@ -317,7 +317,7 @@ class EbbLint(object):
             find_comments(node.prefix, byte - len(node.prefix)))
         for c, i in comments:
             self._intervals['comments'].add(i)
-            m = _pep8_noqa(c)
+            m = _pycodestyle_noqa(c)
             if m is not None:
                 yield self._message_for_pos(
                     self.lines.position_of_byte(i.begin + m.start()),

--- a/ebb_lint/test/test_flake8.py
+++ b/ebb_lint/test/test_flake8.py
@@ -6,7 +6,7 @@ import functools
 import re
 import sys
 
-import pep8
+import pycodestyle
 import pytest
 import six
 from flake8.engine import get_parser
@@ -1189,14 +1189,15 @@ if six.PY2:
         clean_source, error_locations = find_error_locations(source)
         clean_source_bytes = clean_source.encode('utf-8')
         monkeypatch.setattr(
-            pep8, 'stdin_get_value', lambda: clean_source_bytes)
+            pycodestyle, 'stdin_get_value', lambda: clean_source_bytes)
         assert_ebb_lint(clean_source, 'stdin', error_locations)
 
 else:
     @pytest.mark.parametrize('source', all_sources)
     def test_linting_with_stdin_text(monkeypatch, source):
         clean_source, error_locations = find_error_locations(source)
-        monkeypatch.setattr(pep8, 'stdin_get_value', lambda: clean_source)
+        monkeypatch.setattr(pycodestyle, 'stdin_get_value',
+                            lambda: clean_source)
         assert_ebb_lint(clean_source, 'stdin', error_locations)
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extras_require['all'] = list({
 
 
 install_requires = [
-    'flake8 >= 2.5.1',
+    'flake8>=2.6.0',
     'intervaltree',
     'six',
     'venusian',

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ setenv =
     TOX_ENVNAME = {envname}
 deps =
     .[all]
-    coverage < 4
 commands =
     py.test --cov={envsitepackagesdir}/ebb_lint --cov-report=xml -rxs {posargs} {envsitepackagesdir}/ebb_lint
     coverage html -d htmlcov-{envname}


### PR DESCRIPTION
Deals with flake8 >= 2.6.0, which uses post rename pycodestyle.

Branch for PR to habnabit's repo.
